### PR TITLE
Avoid error from async-lry 2.2.0

### DIFF
--- a/overlays/default/default.nix
+++ b/overlays/default/default.nix
@@ -3,6 +3,17 @@
 final: prev: {
   pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [
     (python-final: python-prev: {
+      async-lru =
+        if python-prev.async-lru.version == "2.2.0" then
+          python-prev.async-lru.overrideAttrs (old: rec {
+            version = "2.3.0";
+            src = old.src.override {
+              tag = "v${version}";
+              hash = "sha256-ytmh6tY6AS2VHajCnnRBSi0i57DUu+ikpbil/RwFyYA=";
+            };
+          })
+        else
+          python-prev.async-lru;
       nkeys = python-prev.pkgs.callPackage (inputs.self + "/packages/nkeys-py") { };
       najs = python-prev.pkgs.callPackage (inputs.self + "/packages/najs") {
         inherit inputs;


### PR DESCRIPTION
https://github.com/aio-libs/async-lru/releases/tag/v2.2.0
but 2.3.0 only warns about this.
